### PR TITLE
fix(Favicons): Favicon was linking to 404 

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Copy `config.toml` from `exampleSite` to the root directory of your Hugo site an
 
 ### favicons
 
-This theme contains default favicon with `S` letter. If you want to change it, create a directory `static/assets/img` inside the root of your Hugo site and put your favicon files there. They should have names: `favicon.ico` and `apple-touch-icon.png`.
+This theme contains default favicon with `S` letter. If you want to change it, create a directory `assets/src/images` inside the root of your Hugo site and put your favicon files there. They should have names: `favicon.ico` and `apple-touch-icon.png`.
 
 ## Shortcodes
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -21,8 +21,10 @@
   <link href="//fonts.googleapis.com/css?family=Roboto:400" rel="stylesheet">
 
   <!-- Icons -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ print "/assets/img/apple-touch-icon.png" | relURL }}">
-  <link rel="shortcut icon" href="{{ print "/assets/img/favicon.ico" | relURL }}">
+  {{ $touchicon := resources.Get "/src/images/apple-touch-icon.png" }}
+  {{ $favicon := resources.Get "/src/images/favicon.ico" }}
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ $touchicon.RelPermalink }}">
+  <link rel="shortcut icon" href="{{ $favicon.RelPermalink }}">
 
   <!-- RSS -->
   <link href="{{ $.LanguagePrefix }}{{ "/posts/index.xml" | relURL }}" rel="alternate" type="application/rss+xml" title="{{- .Site.Title -}}" />


### PR DESCRIPTION
Hi!

I noticed that the Favicons weren't working in the exampleSite. This is the fix I came up with. Since the Favicons were saved in the /assets folder,  one has to use `.Permalink/.RelPermalink` on them in order to render them. [https://gohugo.io/hugo-pipes/introduction/#asset-publishing](Hugo/pipes)

I adapted the readme accordingly. Note that the override no longer happens in `/static`  instead it has moved to `/assets`.

I would like you to give the overriding a short test before merging.
Thanks,
Bennet