### PR TITLE
Remove Google News meta tags

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -31,7 +31,6 @@
   <link href="{{ $.LanguagePrefix }}{{ "/posts/index.xml" | relURL }}" rel="alternate" type="application/rss+xml" title="{{- .Site.Title -}}" />
 
   {{ template "_internal/opengraph.html" . }}
-  {{ template "_internal/google_news.html" . }}
   {{ template "_internal/schema.html" . }}
   {{ template "_internal/twitter_cards.html" . }}
 </head>


### PR DESCRIPTION
These have been deprecated.